### PR TITLE
ci: scope down GitHub Token permissions

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -4,6 +4,9 @@ name: "Security Scan: Snyk IaC"
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   snyk:
     runs-on: ubuntu-latest

--- a/.github/workflows/superlinter.yml
+++ b/.github/workflows/superlinter.yml
@@ -4,6 +4,9 @@ name: "Code Quality: Super-Linter"
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   superlinter:
     name: Super-Linter

--- a/.github/workflows/terraform-docs.yml
+++ b/.github/workflows/terraform-docs.yml
@@ -4,6 +4,9 @@ name: "Documentation: terraform-docs"
 on:
   pull_request:
 
+permissions:
+  contents: write
+
 jobs:
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -4,6 +4,9 @@ name: "Security Scan: tfsec"
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   tfsec:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Scope Down GitHub Token Permissions

This PR updates GitHub Actions workflows to use minimal required permissions instead of the default elevated permissions.

### Why This Matters

Following the principle of least privilege, workflows should only have the specific permissions they need to function.

### Changes

This PR adds explicit `permissions:` blocks to workflows that currently rely on default permissions, scoping them down to only what's required for their operations.

Please review the changes to ensure the specified permissions match your workflow requirements.